### PR TITLE
add StringAsFactor=TRUE in data.frame

### DIFF
--- a/R/heatmap3.R
+++ b/R/heatmap3.R
@@ -59,7 +59,8 @@ NULL
 ##' heatmap3(rnormData,ColSideColors=ColSideColors,showRowDendro=FALSE,colorCell=colorCell,
 ##'     highlightCell=highlightCell)
 ##' #A more detail example
-##' ColSideAnn<-data.frame(Information=rnorm(25),Group=c(rep("Control",5), rep(c("TrtA", "TrtB"),10)))
+##' ColSideAnn<-data.frame(Information=rnorm(25),Group=c(rep("Control",5), rep(c("TrtA", 
+##'     "TrtB"),10)),stringsAsFactors=TRUE)
 ##' row.names(ColSideAnn)<-colnames(rnormData)
 ##' RowSideColors<-colorRampPalette(c("chartreuse4", "white", "firebrick"))(40)
 ##' result<-heatmap3(rnormData,ColSideCut=1.2,ColSideAnn=ColSideAnn,ColSideFun=function(x) 

--- a/man/heatmap3.Rd
+++ b/man/heatmap3.Rd
@@ -165,7 +165,8 @@ highlightCell<-data.frame(row=c(2,4,6),col=c(1,3,5),color=c("black","green4","or
 heatmap3(rnormData,ColSideColors=ColSideColors,showRowDendro=FALSE,colorCell=colorCell,
     highlightCell=highlightCell)
 #A more detail example
-ColSideAnn<-data.frame(Information=rnorm(25),Group=c(rep("Control",5), rep(c("TrtA", "TrtB"),10)))
+ColSideAnn<-data.frame(Information=rnorm(25),Group=c(rep("Control",5), rep(c("TrtA", 
+    "TrtB"),10)),stringsAsFactors=TRUE)
 row.names(ColSideAnn)<-colnames(rnormData)
 RowSideColors<-colorRampPalette(c("chartreuse4", "white", "firebrick"))(40)
 result<-heatmap3(rnormData,ColSideCut=1.2,ColSideAnn=ColSideAnn,ColSideFun=function(x) 


### PR DESCRIPTION
added stringsAsFactors=TRUE in example code in data.frame.
The example needs data to be a factor, which is not a default option after update of data.frame. Adding stringsAsFactors=TRUE to make it work.