### PR TITLE
debug object 'result' not found.

### DIFF
--- a/R/heatmap3.R
+++ b/R/heatmap3.R
@@ -91,6 +91,7 @@ heatmap3<-function (x, Rowv = NULL, Colv = if (symm) "Rowv" else NULL,
 	if (!all(is.na(topN))) {
 		temp<-apply(x,1,filterFun)
 		pdf(file)
+		result <- list()
 		for (n in topN) {
 			xSub<-x[rev(order(temp))[1:n],,drop=F]
 			if (!missing(RowSideColors)) {


### PR DESCRIPTION
Question: when the parameter, `topN`, was used, it will cause an error ` "object 'result' not found." `
Reason: The result obj should be created before its call. 
Solution: create the `result` object (a list).